### PR TITLE
simplified how RUL is calculated using transform method with GroupBy

### DIFF
--- a/source/notebooks/sagemaker_predictive_maintenance.ipynb
+++ b/source/notebooks/sagemaker_predictive_maintenance.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,10 @@
     "with zipfile.ZipFile(os.path.join(data_folder, 'CMAPSSData.zip'), \"r\") as zip_ref:\n",
     "    zip_ref.extractall(data_folder)\n",
     "    \n",
-    "columns = ['id', 'cycle', 'setting1', 'setting2', 'setting3', 's1', 's2', 's3','s4', 's5', 's6', 's7', 's8', 's9', 's10', 's11', 's12', 's13', 's14','s15', 's16', 's17', 's18', 's19', 's20', 's21']"
+    "columns = ['id', 'cycle', 'setting1', 'setting2', 'setting3', \n",
+    "           's1', 's2', 's3','s4', 's5', 's6', 's7', 's8', 's9', \n",
+    "           's10', 's11', 's12', 's13', 's14','s15', 's16', 's17', \n",
+    "           's18', 's19', 's20', 's21']"
    ]
   },
   {
@@ -63,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,18 +76,11 @@
     "for i in range(1,5):\n",
     "    df = pd.read_csv('data/train_FD{:03d}.txt'.format(i), delimiter=' ', header=None)\n",
     "    df.drop(df.columns[[26, 27]], axis=1, inplace=True)\n",
-    "    df.columns = columns\n",
+    "    df.columns=columns\n",
+    "    df['max'] = df.groupby(['id'])['cycle'].transform(max)\n",
+    "    df['RUL'] = df['max'] - df['cycle']\n",
     "    df[columns[2:]]=(df[columns[2:]]-df[columns[2:]].min()+eps)/(df[columns[2:]].max()-df[columns[2:]].min()+eps)\n",
     "    train_df.append(df)\n",
-    "\n",
-    "# compute RUL (remaining useful life)\n",
-    "for i, df in enumerate(train_df):\n",
-    "    rul = pd.DataFrame(df.groupby('id')['cycle'].max()).reset_index()\n",
-    "    rul.columns = ['id', 'max']\n",
-    "    df = df.merge(rul, on=['id'], how='left')\n",
-    "    df['RUL'] = df['max'] - df['cycle']\n",
-    "    df.drop('max', axis=1, inplace=True)\n",
-    "    train_df[i]=df\n",
     "\n",
     "train_df[0].head()\n",
     "o = train_df[0][columns[2:10]][train_df[0]['id'] == 3].plot(subplots=True, sharex=True, figsize=(20,10), title=\"Train: 8 sensors of Engine 1 before failure\")"
@@ -101,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Original version uses complicated approach to find the max number of cycles for each id. Using pd.DataFrame.transform with pd.Groupby, we can find the max value for each id and assign it to the the proper column. This prevents making extra copies of the DataFrame and then merging those slices. 

**Original:**
```
for i, df in enumerate(train_df):
    rul = pd.DataFrame(df.groupby('id')['cycle'].max()).reset_index()
    rul.columns = ['id', 'max']
    df = df.merge(rul, on=['id'], how='left')
    df['RUL'] = df['max'] - df['cycle']
    df.drop('max', axis=1, inplace=True)
    train_df[i]=df
```

**revised:**
```
df['max'] = df.groupby(['id'])['cycle'].transform(max)
df['RUL'] = df['max'] - df['cycle']
```
This code could be further simplified by using the "names" argument to assign the labels to the columns. I didn't make this change because the way the columns list is used for the test datasets causes issues. However, the process for reading in the data for the test data is also needlessly complex.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
